### PR TITLE
Added ApexCharts to the window variable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 import ApexCharts from "apexcharts"
+window.ApexCharts = ApexCharts;
 
 export const chart = (node, options) => {
   let myChart = new ApexCharts(node, options)


### PR DESCRIPTION
If i don't put ApexCharts into the window variable, using brush typed chart return the fallowing error:
**ReferenceError: ApexCharts is not defined**

The same issue was in react-apexcharts and it was fixed like this in version 1.2.1
Link to the commit in react-apexcharts: https://github.com/apexcharts/react-apexcharts/commit/1463c945fdb780f2f502a1fd00ff306f66c4c664